### PR TITLE
[ADD] Ioka Client class description in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,9 @@ Create client, using api key and endpoint url:
 
    client = ioka.Ioka(api_key=..., base_url=...)
 
-Ioka Client parameters usage:
+Ioka Client class arguments description:
 
- api_key - Your secret key provided by Ioka https://ioka.kz/#application-form
+ api_key - Your secret key provided by Ioka, fill form to get API key https://ioka.kz/#application-form
 
  base_url - URL for sending requests, https://stage-api.ioka.kz by default
 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,12 @@ Create client, using api key and endpoint url:
 
    client = ioka.Ioka(api_key=..., base_url=...)
 
+Ioka Client parameters usage:
+
+ api_key - Your secret key provided by Ioka https://ioka.kz/#application-form
+
+ base_url - URL for sending requests, https://stage-api.ioka.kz by default
+
 Usage
 -----
 


### PR DESCRIPTION
Description of `class Ioka(...)` in the README of what the class arguments mean.

- Added reference to application-form for API keys
- Described what is base_url stands for